### PR TITLE
Implement differentiable binarization and mask erosion

### DIFF
--- a/text_detection/eval.py
+++ b/text_detection/eval.py
@@ -24,11 +24,12 @@ def main():
     parser.add_argument("out_basename")
     args = parser.parse_args()
 
-    model = DetectionModel()
+    model = DetectionModel(eval_only=True)
     model.eval()
 
     checkpoint = torch.load(args.model, map_location=torch.device("cpu"))
-    model.load_state_dict(checkpoint["model_state"])
+    model_state = DetectionModel.get_eval_only_state(checkpoint["model_state"])
+    model.load_state_dict(model_state)
 
     input_img = read_image(args.image, ImageReadMode.GRAY)
     _, input_height, input_width = input_img.shape
@@ -56,18 +57,42 @@ def main():
     binary_mask = resize(
         binary_mask, (input_height, input_width), InterpolationMode.NEAREST
     )
-    text_mask = binary_mask[0]
-    text_regions = (input_img.float() / 255.0) * text_mask
 
-    to_pil_image(text_regions).save(f"{args.out_basename}-text-regions.png")
-    to_pil_image(pred_masks[0]).save(f"{args.out_basename}-text-probs.png")
+    text_prob_mask = binary_mask[0]
+    text_prob_regions = (input_img.float() / 255.0) * text_prob_mask
+
+    to_pil_image(text_prob_regions).save(f"{args.out_basename}-prob-regions.png")
+    to_pil_image(text_prob_mask).save(f"{args.out_basename}-prob-mask.png")
+
+    prob_pred = pred_masks[0]
+    to_pil_image(prob_pred).save(f"{args.out_basename}-prob-pred.png")
 
     # Extract word quads and expand them to compensate for the shrinking that is
     # applied to text polygons when text masks are generated during training.
-    word_quads = extract_cc_quads(text_mask)
+    word_quads = extract_cc_quads(text_prob_mask)
     word_quads = expand_quads(word_quads, dist=SHRINK_DISTANCE)
     word_quad_image = draw_quads(input_img, word_quads)
     word_quad_image.save(f"{args.out_basename}-text-words.png")
+
+    # By default the model only outputs the probability mask during inference.
+    # If binary and threshold mask output has also been enabled, then save those.
+    #
+    # The binary mask is trained with the same supervision as the probability
+    # mask, so it should be almost identical.
+    if len(pred_masks) > 1:
+        text_bin_mask = binary_mask[1]
+        text_bin_regions = (input_img.float() / 255.0) * text_bin_mask
+        bin_prob_diff = text_prob_mask.logical_xor(text_bin_mask).float()
+
+        to_pil_image(text_bin_regions).save(f"{args.out_basename}-bin-regions.png")
+        to_pil_image(text_bin_mask).save(f"{args.out_basename}-bin-mask.png")
+        to_pil_image(bin_prob_diff).save(f"{args.out_basename}-prob-bin-diff.png")
+
+        bin_pred = pred_masks[1]
+        to_pil_image(bin_pred).save(f"{args.out_basename}-bin-pred.png")
+
+        thresh_pred = pred_masks[2]
+        to_pil_image(thresh_pred).save(f"{args.out_basename}-thresh-pred.png")
 
 
 if __name__ == "__main__":

--- a/text_detection/eval.py
+++ b/text_detection/eval.py
@@ -52,7 +52,7 @@ def main():
     print(f"Predicted text in {end - start:.2f}s", file=sys.stderr)
 
     pred_masks = pred_masks[0]  # Remove dummy batch dimension
-    threshold = 0.3
+    threshold = 0.5
     binary_mask = binarize_mask(pred_masks, threshold=threshold)
     binary_mask = resize(
         binary_mask, (input_height, input_width), InterpolationMode.NEAREST

--- a/text_detection/model.py
+++ b/text_detection/model.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import torch
 from torch import nn
 
@@ -85,45 +87,87 @@ class Up(nn.Module):
         return self.contract(combined)
 
 
+def binarize(
+    pred_mask: torch.Tensor, thresh_mask: torch.Tensor, k: float = 50
+) -> torch.Tensor:
+    """
+    Differentiable Binarization function, from https://arxiv.org/abs/1911.08947.
+
+    :param pred_mask: B1HW tensor of binary class probabilities
+    :param thresh_mask: B1HW tensor of thresholds
+    :param k: Amplifying factor (see eqn 2 of paper). Defaults to the value of
+      50 given in the paper.
+    :return: B1HW tensor of binary class probabilities
+    """
+    return (k * (pred_mask - thresh_mask)).sigmoid()
+
+
 class DetectionModel(nn.Module):
     """
     Text detection model.
 
-    This uses a U-Net-like architecture. See https://arxiv.org/abs/1505.04597.
+    This uses a U-Net architecture (https://arxiv.org/abs/1505.04597) for
+    feature extraction and upsampling, coupled with a Differentiable
+    Binarization (https://arxiv.org/abs/2202.10304) head.
 
-    It expects a greyscale image as input and outputs a text/not-text
-    segmentation mask.
+    The model expects a greyscale image as input and outputs a text/not-text
+    segmentation mask during inference. During training it also outputs a
+    post-binarization and binarization threshold masks (see DB paper).
     """
 
-    def __init__(self):
+    def __init__(self, eval_only=False):
+        """
+        :param eval_only: If true, configure the model for inference only.
+          Params used only during training will be excluded. When loading a
+          saved state dict, the dict will need to be prepared using
+          `get_eval_only_state`.
+        """
         super().__init__()
 
-        # Number of feature channels at each size level in the network.
+        # Number of feature channels at each level in the network.
         #
         # The U-Net paper uses 64 for the first level. This model uses a
         # reduced scale to cut down the parameter count.
-        #
-        # depth_scale = [64, 128, 256, 512, 1024]
-        depth_scale = [8, 16, 32, 32, 64, 128, 256]
-        self.depth_scale = depth_scale
+        width_scale = [8, 16, 32, 32, 64, 128, 256]
+        self.depth_scale = width_scale
 
-        self.in_conv = DoubleConv(1, depth_scale[0])
+        # Feature extraction and upsampling network.
+        self.in_conv = DoubleConv(1, width_scale[0])
 
         self.down = nn.ModuleList()
-        for i in range(len(depth_scale) - 1):
-            self.down.append(Down(depth_scale[i], depth_scale[i + 1]))
+        for i in range(len(width_scale) - 1):
+            self.down.append(Down(width_scale[i], width_scale[i + 1]))
 
         self.up = nn.ModuleList()
-        for i in range(len(depth_scale) - 1):
-            self.up.append(Up(depth_scale[i + 1], depth_scale[i], depth_scale[i]))
+        for i in range(len(width_scale) - 1):
+            self.up.append(Up(width_scale[i + 1], width_scale[i], width_scale[i]))
 
-        n_masks = 1  # Output masks to generate
-        self.out_conv = nn.Sequential(
-            nn.Conv2d(depth_scale[0], n_masks, kernel_size=1, padding="same"),
+        # Head for text/not-text probability mask.
+        self.prob_head = nn.Sequential(
+            nn.Conv2d(width_scale[0], width_scale[0], kernel_size=1, padding="same"),
+            nn.ReLU(),
+            nn.Conv2d(width_scale[0], width_scale[0], kernel_size=1, padding="same"),
+            nn.ReLU(),
+            nn.Conv2d(width_scale[0], 1, kernel_size=1, padding="same"),
             nn.Sigmoid(),
         )
 
-    def forward(self, x: torch.Tensor):
+        # Head for binarization threshold mask.
+        if not eval_only:
+            self.thresh_head = nn.Sequential(
+                nn.Conv2d(
+                    width_scale[0], width_scale[0], kernel_size=1, padding="same"
+                ),
+                nn.ReLU(),
+                nn.Conv2d(
+                    width_scale[0], width_scale[0], kernel_size=1, padding="same"
+                ),
+                nn.ReLU(),
+                nn.Conv2d(width_scale[0], 1, kernel_size=1, padding="same"),
+                nn.Sigmoid(),
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.in_conv(x)
 
         x_down: list[torch.Tensor] = []
@@ -135,4 +179,29 @@ class DetectionModel(nn.Module):
         for i, up_op in reversed(list(enumerate(self.up))):
             x_up = up_op(x_up, x if i == 0 else x_down[i - 1])
 
-        return self.out_conv(x_up)
+        prob_mask = self.prob_head(x_up)
+        if not self.training:
+            return prob_mask
+
+        thresh_mask = self.thresh_head(x_up)
+
+        k_factor = 10
+        # k_factor = 50.
+        bin_mask = binarize(prob_mask, thresh_mask, k=k_factor)
+        return torch.cat([prob_mask, bin_mask, thresh_mask], dim=1)
+
+    @staticmethod
+    def get_eval_only_state(
+        state_dict: OrderedDict[str, torch.Tensor]
+    ) -> OrderedDict[str, torch.Tensor]:
+        """
+        Strip training-only params from a saved model.
+
+        Return a copy of `state_dict` with params that are not used in eval-only
+        mode removed.
+        """
+        result = state_dict.copy()
+        for key in list(result.keys()):
+            if key.startswith("thresh_head."):
+                del result[key]
+        return result

--- a/text_detection/model.py
+++ b/text_detection/model.py
@@ -22,7 +22,7 @@ class DepthwiseConv(nn.Module):
             nn.ReLU(),
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.seq(x)
 
 
@@ -35,7 +35,7 @@ class DoubleConv(nn.Module):
             DepthwiseConv(out_channels, out_channels),
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.seq(x)
 
 
@@ -52,7 +52,7 @@ class Down(nn.Module):
             nn.MaxPool2d(kernel_size=2),
         )
 
-    def forward(self, x: torch.Tensor):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.seq(x)
 
 
@@ -76,7 +76,7 @@ class Up(nn.Module):
         )
         self.contract = DoubleConv(out_channels + in_cross_channels, out_channels)
 
-    def forward(self, x_to_upscale: torch.Tensor, x: torch.Tensor):
+    def forward(self, x_to_upscale: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
         upscaled = self.up(x_to_upscale)
         pad_r = x.shape[3] - upscaled.shape[3]
         pad_b = x.shape[2] - upscaled.shape[2]


### PR DESCRIPTION
Implement two changes to make it easier to segment individual words and lines out of the text mask. With the initial U-Net model adjacent words and lines were prone to running together, making them difficult to separate. The plan is to feed the detection results into a model which processes text lines, so the main separation that matters is between adjacent lines.

- Use opencv-python to erode the masks for each word in the target mask. This helps create more clearly defined boundaries between adjacent text instances
- Add differentiable binarization (https://arxiv.org/abs/1911.08947). Not all elements of this paper are implemented, just the core element consisting of the probability / threshold head separation and the differentiable binarization function.

Adding DB introduces parameters and computations into the model which are only needed at training time. To optimize inference speed, an `eval_only` option has been added to `DetectionModel` which controls whether training-only parameters are added, and `module.training` checks have been added in the `forwards` pass to skip unnecessary computation during inference.

Below are some comparison images of 7a22d8bfc431806736311b6b6a9624cf9d931695 (+erosion, +data augmentation +higher res mask, -db) vs 0f673888c5e6e150dd556199a47e8d4d4b4cec23 (+erosion, +data augmentation +higher res mask, +db). The main difference to note is that a sequence of words are less often combined into the same region in the version with DB.

There is a downside to adding DB, which is that the loss starts out much higher and takes more epochs to come down to a low value (around 0.10), so it might be worth exploring ways to speed up convergence or other ways to increase separation around the boundaries of text elements.

**Without differentiable binarization:**

<img width="500" src="https://user-images.githubusercontent.com/2458/179368850-92b8e140-41b3-4d90-b37a-59768b49beb3.png">

**With differentiable binarization:**

<img width="500" src="https://user-images.githubusercontent.com/2458/179368857-d0fc8f52-3c28-47a6-a028-54b3e070a9c1.png">

**Without differentiable binarization (2):**

<img width="500" src="https://user-images.githubusercontent.com/2458/179368960-f373ec77-e1a8-4f7f-912c-48b1584a3f5f.png">

**With differentiable binarization (2) :**

<img width="500" src="https://user-images.githubusercontent.com/2458/179369024-3dbddcc4-ae0e-4dae-8085-d0617d2c3bc9.png">

