### PR TITLE
Fix tqdm import in ocrs_models.datasets.hiertext

### DIFF
--- a/ocrs_models/datasets/hiertext.py
+++ b/ocrs_models/datasets/hiertext.py
@@ -6,7 +6,7 @@ from typing import Optional, cast
 import torch
 from torchvision.io import ImageReadMode, read_image, write_png
 from torchvision.transforms.functional import resize
-import tqdm
+from tqdm import tqdm
 
 from .util import (
     Polygon,


### PR DESCRIPTION
Fix a mistake from when the `ocrs_models.datasets` module was converted into a package in 8ca41d5b1cd1f2bd3cad16ff10bd27404cfe5d9e.

mypy didn't catch this because type checking was disabled for tqdm due to lack of types.

See https://github.com/robertknight/ocrs-models/issues/27.